### PR TITLE
IExternal: Add the legacy ICatalog::Resource() interface method

### DIFF
--- a/interfaces/IExternal.h
+++ b/interfaces/IExternal.h
@@ -45,6 +45,7 @@ namespace Exchange {
             // Pushing notifications to interested sinks
             virtual void Register(ICatalog::INotification* sink) = 0;
             virtual void Unregister(ICatalog::INotification* sink) = 0;
+            virtual IExternal* Resource(const uint32_t id) = 0;
         };
 
         //  Basic/specific and dimension together define the Type.


### PR DESCRIPTION
The ICatalog::Resource() interface method is required for directly
getting the IExternal pointer to a give Pin ID, without having to listen
to ICatalog notifications.