### PR TITLE
XIONE-3049: Adding some more resolutions

### DIFF
--- a/interfaces/IPlayerInfo.h
+++ b/interfaces/IPlayerInfo.h
@@ -104,7 +104,8 @@ namespace Exchange {
             RESOLUTION_2160P25,
             RESOLUTION_2160P30,
             RESOLUTION_2160P50,
-            RESOLUTION_2160P60
+            RESOLUTION_2160P60,
+            RESOLUTION_2160P
         };
 
         // @property


### PR DESCRIPTION
Reason for change: Adding some more resoltuions
that are supported by comcast boxes. Missed to
add 2160p previously
Test Procedure: None
Risks: None
Signed-off-by: Vinod Jacob <vinod_jacob@comcast.com>