### PR TITLE
RDK-29971: Add return codes

### DIFF
--- a/jsonrpc/Messenger.json
+++ b/jsonrpc/Messenger.json
@@ -11,18 +11,18 @@
   },
   "methods": {
     "Messenger.1.create": {
-      "summary": "Creates a messaging room name and URL regex",
+      "summary": "Sets URL regex for a messaging room",
       "description": "Only apps that match the regex will be allowed to join the room",
       "params": {
         "type": "object",
         "properties": {
           "room": {
-            "description": "Name of the room to create (must not be empty)",
+            "description": "Name of the room (must not be empty)",
             "type": "string",
             "example": "Lounge"
           },
           "urlRegex": {
-            "description": "URL regex to match apps (must not be empty)",
+            "description": "URL regex (must not be empty)",
             "type": "string",
             "example": "*://*.local:*"
           }
@@ -36,6 +36,10 @@
         "$ref": "#/common/results/void"
       },
       "errors": [
+        {
+          "description": "Room is being used (i.e. there are users in it)",
+          "$ref": "#/common/errors/illegalstate"
+        },
         {
           "description": "Room name or URL regex was invalid",
           "$ref": "#/common/errors/badrequest"


### PR DESCRIPTION
Reason for change: Add return code ERROR_ILLEGAL_STATE
for Messenger.1.create.
Test Procedure: See ticket
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>