### PR TITLE
Fix wifi jsonrpc signal type and size

### DIFF
--- a/jsonrpc/WifiControl.json
+++ b/jsonrpc/WifiControl.json
@@ -66,6 +66,8 @@
         },
         "signal": {
           "type": "number",
+          "signed": true,
+          "size": 32,
           "example": -44,
           "description": "Network's signal level in dBm"
         }


### PR DESCRIPTION
I get incorrect type Core::JSON::DecUInt32 Signal; in https://github.com/rdkcentral/Thunder/tree/f53eec83fe4d09daff30f2bdbfa908e2d8dfa4f6
wifi signal will display incorrectly

Add these for safety