### PR TITLE
[WebKit] json rpc interface compatible

### DIFF
--- a/interfaces/IBrowser.h
+++ b/interfaces/IBrowser.h
@@ -55,7 +55,7 @@ namespace Exchange {
     struct EXTERNAL IWebBrowser : virtual public Core::IUnknown {
         enum { ID = ID_WEB_BROWSER };
 
-        enum Visibility : uint8_t {
+        enum VisibilityType : uint8_t {
             HIDDEN = 0,
             VISIBLE = 1,
         };
@@ -66,21 +66,21 @@ namespace Exchange {
             ONLY_FROM_MAIN_DOCUMENT_DOMAIN = 2,
             EXCLUSIVELY_FROM_MAIN_DOCUMENT_DOMAIN = 3
         };
-
-        /* @event */
+        
+        /* @event @extended */  // NOTE: extended format is deprecated!! Do not just copy this line!
         struct INotification : virtual public Core::IUnknown {
             enum { ID = ID_WEBKITBROWSER_NOTIFICATION };
 
             // Signal changes on the subscribed namespace..
             // @brief Initial HTML document has been completely loaded and parsed
-            // @param URL The URL that has been loaded
-            // @param code The response code of main resource request
-            virtual void LoadFinished(const string& URL, const int32_t code) = 0;
+            // @param URL The URL that has been loaded (e.g. https://example.com)
+            // @param httpstatus The response code of main resource request (e.g. 200)
+            virtual void LoadFinished(const string& URL, const int32_t httpstatus) = 0;
             // @brief Browser failed to load page
-            // @param URL The URL that has been failed to load
+            // @param URL The URL that has been failed to load (e.g. https://example.com)
             virtual void LoadFailed(const string& URL) = 0;
             // @brief Signals a URL change in the browser
-            // @param URL The URL that has been loaded or requested
+            // @param URL The URL that has been loaded or requested (e.g. https://example.com)
             // @param loaded loaded (true) or not (false)
             virtual void URLChange(const string& URL, const bool loaded) = 0;
             // @brief Signals a visibility change of the browser
@@ -89,7 +89,7 @@ namespace Exchange {
             // @brief Notifies that the web page requests to close its window
             virtual void PageClosure() = 0;
             // @brief Base64 encoded JSON message from legacy $badger bridge
-            virtual void BridgeQuery(const string& message) = 0;
+            virtual void BridgeQueryResponse(const string& message) = 0;
         };
 
         virtual void Register(INotification* sink) = 0;
@@ -97,15 +97,15 @@ namespace Exchange {
 
         // @property
         // @brief Page loaded in the browser
-        // @param url Loaded URL
+        // @param url Loaded URL (e.g. https://example.com)
         virtual uint32_t URL(string& url /* @out */) const = 0;
         virtual uint32_t URL(const string& url) = 0;
 
         // @property
         // @brief Browser window visibility state
-        // @param visible Visiblity state
-        virtual uint32_t Visible(bool& visible /* @out */) const = 0;
-        virtual uint32_t Visible(const bool visible) = 0;
+        // @param visible Visiblity state (e.g. )
+        virtual uint32_t Visibility(VisibilityType& visible /* @out */) const = 0;
+        virtual uint32_t Visibility(const VisibilityType visible) = 0;
 
         // @property
         // @brief Current framerate the browser is rendering at
@@ -114,21 +114,15 @@ namespace Exchange {
 
         // @property
         // @brief Headers to send on all requests that the browser makes
-        // @param header Header Name
-        virtual uint32_t Headers(string& header /* @out */) const = 0;
-        virtual uint32_t Headers(const string& header) = 0;
+        // @param headerlist Header Names 
+        virtual uint32_t HeaderList(string& headerlist /* @out */) const = 0;
+        virtual uint32_t HeaderList(const string& headerlist ) = 0;
 
         // @property
         // @brief UserAgent string used by the browser
-        // @param useragent UserAgent value
-        virtual uint32_t UserAgent(string& ua /* @out */) const = 0;
-        virtual uint32_t UserAgent(const string& ua) = 0;
-
-        // @property
-        // @brief User preferred languages used by the browser
-        // @param language Preferred language
-        virtual uint32_t Languages(string& langs /* @out */) const = 0;
-        virtual uint32_t Languages(const string& langs) = 0;
+        // @param useragent UserAgent value (e.g. Mozilla/5.0 (Linux; x86_64 GNU/Linux) AppleWebKit/601.1 (KHTML, like Gecko) Version/8.0 Safari/601.1 WP)
+        virtual uint32_t UserAgent(string& useragent /* @out */) const = 0;
+        virtual uint32_t UserAgent(const string& useragent) = 0;
 
         // @property
         // @brief Controls the local storage availability
@@ -138,15 +132,18 @@ namespace Exchange {
 
         // @property
         // @brief HTTP cookies accept policy
-        // @param policy HTTP Cookie Accept Policy Type
+        // @param policy HTTP Cookie Accept Policy Type (e.g. always)
         virtual uint32_t HTTPCookieAcceptPolicy(HTTPCookieAcceptPolicyType& policy /* @out */) const = 0;
         virtual uint32_t HTTPCookieAcceptPolicy(const HTTPCookieAcceptPolicyType policy) = 0;
 
+        // @property
         // @brief Response for legacy $badger.
-        // @param payload base64 encoded JSON string response to be delivered to $badger.callback(pid, success, json)
+        // @param payload base64 encoded JSON string response to be delivered to $badger.callback
         virtual uint32_t BridgeReply(const string& payload) = 0;
+
+        // @property
         // @brief Send legacy $badger event.
-        // @param payload base64 encoded JSON string response to be delivered to window.$badger.event(handlerId, json)
+        // @param payload base64 encoded JSON string response to be delivered to window.$badger.event
         virtual uint32_t BridgeEvent(const string& payload) = 0;
 
         // @brief Initiate garbage collection

--- a/interfaces/IDisplayInfo.h
+++ b/interfaces/IDisplayInfo.h
@@ -51,7 +51,7 @@ namespace Exchange {
             HDCP_AUTO
         };
 
-        /* @event */
+        /* @event @extended */  // NOTE: extended format is deprecated!! Do not just copy this line!
         struct EXTERNAL INotification : virtual public Core::IUnknown {
             enum { ID = ID_CONNECTION_PROPERTIES_NOTIFICATION };
 

--- a/interfaces/IVolumeControl.h
+++ b/interfaces/IVolumeControl.h
@@ -28,7 +28,7 @@ namespace Exchange {
     struct EXTERNAL IVolumeControl : virtual public Core::IUnknown {
         enum { ID = ID_VOLUMECONTROL };
 
-        // @event
+        /* @event @extended */  // NOTE: extended format is deprecated!! Do not just copy this line!
         struct EXTERNAL INotification : virtual public Core::IUnknown {
             enum { ID = ID_VOLUMECONTROL_NOTIFICATION };
 

--- a/jsonrpc/WebKitBrowser.json
+++ b/jsonrpc/WebKitBrowser.json
@@ -10,46 +10,36 @@
       "$ref": "common.json"  
     },
     "include": {
-      "browser": {
-        "$ref": "Browser.json#"
-      },
       "statecontrol": {
         "$ref": "StateControl.json#"
       }
     },
-    "properties": {
-    "useragent": {
-      "summary": "UserAgent string used by browser",
+    "methods": {
+      "delete": {
+        "summary": "Removes contents of a directory from the persistent storage",
+        "description": "Use this method to recursively delete contents of a directory",
         "params": {
-          "type": "string",
-          "example": "Mozilla/5.0 (Linux; x86_64 GNU/Linux) AppleWebKit/601.1 (KHTML, like Gecko) Version/8.0 Safari/601.1 WP"
-        }
-    },
-    "httpcookieacceptpolicy": {
-      "summary": "HTTP cookies accept policy",
-      "params": {
-        "type": "string",
-        "enum": [
-          "always",
-          "never",
-          "onlyfrommaindocumentdomain",
-          "exclusivelyfrommaindocumentdomain"
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string",
+              "description": "Path to directory (within the persistent storage) to delete contents of",
+              "example": ".cache/wpe/disk-cache"
+            }
+          }
+        },
+        "result": {
+          "$ref": "#/common/results/void"
+        },
+        "errors": [
+          {
+            "description": "The given path was incorrect",
+            "$ref": "#/common/errors/unknownkey"
+          }
         ]
-      },
-      "errors": [
-        {
-          "code": 22,
-          "message": "ERROR_UNKNOWN_KEY",
-          "description": "Unknown policy"
-        }
-      ]
-    },
-    "localstorageenabled": {
-      "summary": "Controls the local storage availability",
-        "params": {
-          "type": "boolean"
-        }
-    },
+      }
+  },
+  "properties": {
     "languages": {
       "summary": "User preferred languages",
       "params": {
@@ -80,106 +70,9 @@
           }
         }
       }
-    }
-  },
-    "methods": {
-    "bridgereply": {
-      "summary": "A response for legacy $badger",
-      "params": {
-        "description": "A base64 encoded JSON string response to be delivered to $badger.callback(pid, success, json)",
-        "type": "string",
-        "properties": {
-          "pid": {
-            "type": "number",
-            "description": "The $badger promise Id associated with query"
-          },
-          "success": {
-            "type": "boolean",
-            "description": "Which $badger promise callback to invoke"
-          },
-          "json": {
-            "type": "object",
-            "description": "Payload to pass to the $badger promise callback",
-            "properties": {},
-            "required": []
-          }
-        },
-        "required": [
-          "pid",
-          "success"
-        ]
-      },
-      "result": {
-        "type": "null"
-      }
-    },
-    "bridgeevent": {
-      "summary": "Send legacy $badger event",
-      "params": {
-        "description": "A base64 encoded JSON string response to be delivered to window.$badger.event(handlerId, json)",
-        "type": "string",
-        "properties": {
-          "handlerId": {
-            "type": "number",
-            "description": "The $badger handler Id"
-          },
-          "json": {
-            "type": "object",
-            "description": "Payload to pass to the $badger",
-            "properties": {},
-            "required": []
-          }
-        },
-        "required": [
-          "handlerId",
-          "json"
-        ]
-      },
-      "result": {
-        "type": "null"
-      }
-    }
+    }  
   },
   "events": {
-    "loadfinished": {
-      "summary": "Initial HTML document has been completely loaded and parsed",
-      "params": {
-        "type": "object",
-        "properties": {
-          "url": {
-            "description": "The URL that has been loaded",
-            "type": "string",
-            "example": "https://example.com"
-          },
-          "httpstatus": {
-            "description": "The response code of main resource request",
-            "type": "integer",
-            "signed": true,
-            "example": 200
-          }
-        },
-        "required": [
-          "url",
-          "httpstatus"
-        ]
-      }
-    },
-    "loadfailed": {
-      "summary": "Browser failed to load page",
-      "params": {
-        "type": "object",
-        "properties": {
-          "url": {
-            "description": "The URL that browser failed to load",
-            "type": "string",
-            "example": "https://example.com"
-          }
-        },
-        "required": [
-          "url"
-        ]
-      }
-    },
     "bridgequery": {
       "summary": "A Base64 encoded JSON message from legacy $badger bridge",
       "params": {


### PR DESCRIPTION

This updates the WebBrowser json rpc interface to be gererated (as much as possible) from the IWebBrowser interface while remaining backwards compatible with the already published json rpc interface (that was at that time generated from the json meta file instead of the C++ header file)

Also a first integration of the IApplication interface to WebKit was done but it is not yet complete and there will be no json rpc interface generated for it. 

Please note that these changes will (to some extend) break the current COM RPC interface and the json rpc interface generated from the IBrowser.h file.

The following pull request all belong to this and must be submitted together:

https://github.com/WebPlatformForEmbedded/ThunderNanoServicesRDK/pull/39
https://github.com/rdkcentral/ThunderInterfaces/pull/41
https://github.com/rdkcentral/Thunder/pull/524

For the HeaderList method no example value is yet added to the header file (and therefore also not included to the documentation) as the json rpc generator needs to be extended to be able to handle the content for that