### PR TITLE
[WiFi] Error codes

### DIFF
--- a/jsonrpc/WifiControl.json
+++ b/jsonrpc/WifiControl.json
@@ -152,7 +152,13 @@
       },
       "result": {
         "$ref": "#/common/results/void"
-      }
+      },
+      "errors": [
+        {
+          "description": "Returned when unable to update config list stored on disk",
+          "$ref": "#/common/errors/unavailable"
+        }
+      ]
     },
     "store": {
       "summary": "Stores the configurations in persistent storage",
@@ -204,6 +210,10 @@
       "errors": [
         {
           "description": "Returned when the network with a the given SSID doesn't exists",
+          "$ref": "#/common/errors/notexist"
+        },
+        {
+          "description": "Returned when the network with a the given security type doesn't exists",
           "$ref": "#/common/errors/unknownkey"
         },
         {


### PR DESCRIPTION

- Differentiate between situations when there is no SSID and there is a wrong WPA method specified. ( https://github.com/rdkcentral/ThunderNanoServices/pull/455)
- Add error to communicate that plugin was not able to update configs on the disk (https://github.com/rdkcentral/ThunderNanoServices/pull/453)
