### PR TITLE
RDKTV-9419: Playerinfo to include AUTO mode for sound settings

### DIFF
--- a/interfaces/IDolby.h
+++ b/interfaces/IDolby.h
@@ -46,7 +46,8 @@ namespace Exchange {
                 MONO,
                 STEREO,
                 SURROUND,
-                PASSTHRU
+                PASSTHRU,
+                SOUNDMODE_AUTO
             };
 
             /* @event */


### PR DESCRIPTION
Reason for change: Comcast TV platforms let the user select "Auto" mode
which automatically detects the max capability of the connected AVR
and transcodes the incoming stream to match the max caps of the AVR
wherever possible.
Signed-off-by: Vinod Jacob vinod_jacob@comcast.com