### PR TITLE
Don't generate 'headers' for JSONRPC from IBrowserResources interface

### DIFF
--- a/interfaces/IBrowser.h
+++ b/interfaces/IBrowser.h
@@ -161,7 +161,9 @@ namespace Exchange {
         // @property
         // @brief Headers to send on all requests that the browser makes
         // @param header Header Name
+        // @json:omit
         virtual uint32_t Headers(IStringIterator*& header /* @out */) const = 0;
+        // @json:omit
         virtual uint32_t Headers(IStringIterator* const header) = 0;
 
         // @property


### PR DESCRIPTION
The callbacks for 'headers' property are already registered in WebKitBrowser-plugin
in case of JSONRPC - WebKitBrowserJsonRpc.cpp