### PR TITLE
Metrol330

### DIFF
--- a/interfaces/IBluetooth.h
+++ b/interfaces/IBluetooth.h
@@ -20,12 +20,13 @@
 #pragma once
 #include "Module.h"
 
-// @stubgen:skip
+
 
 namespace WPEFramework {
 
 namespace Exchange {
 
+    // @stubgen:omit
     struct EXTERNAL IBluetooth : virtual public Core::IUnknown {
         enum { ID = ID_BLUETOOTH };
 

--- a/interfaces/IBrowser.h
+++ b/interfaces/IBrowser.h
@@ -20,7 +20,7 @@
 #pragma once 
 #include "Module.h"
 
-// @stubgen:include <com/IRPCIterator.h>
+// @stubgen:include <com/IIteratorType.h>
 
 namespace WPEFramework {
 namespace Exchange {

--- a/interfaces/IButler.h
+++ b/interfaces/IButler.h
@@ -2,13 +2,14 @@
 
 #include "Module.h"
 
-// @stubgen:skip
+
 
 namespace WPEFramework {
 	namespace Exchange {
-
+		// @stubgen:omit
         struct IExternal;
 
+		// @stubgen:omit
 		struct EXTERNAL IGroup : virtual public Core::IUnknown {
 
 			enum { ID = ID_BUTLER_GROUP };
@@ -18,6 +19,7 @@ namespace WPEFramework {
 			virtual RPC::IStringIterator* Names() const = 0;
 		};
 
+		// @stubgen:omit
 		struct EXTERNAL IButler : virtual public Core::IUnknown {
 
 			enum { ID = ID_BUTLER };

--- a/interfaces/ICapture.h
+++ b/interfaces/ICapture.h
@@ -20,11 +20,12 @@
 #pragma once
 #include "Module.h"
 
-// @stubgen:skip
+
 
 namespace WPEFramework {
 namespace Exchange {
 
+    // @stubgen:omit
     struct EXTERNAL ICapture : virtual public Core::IUnknown {
         enum { ID = ID_CAPTURE };
 

--- a/interfaces/ICommand.h
+++ b/interfaces/ICommand.h
@@ -20,13 +20,12 @@
 #pragma once
 #include "Module.h"
 
-// @stubgen:skip
-
 namespace WPEFramework {
 namespace Exchange {
 
     // This interface gives the possibility to create/defines commmands to be executed by
     // the CommanderPlugin
+    // @stubgen:omit
     struct EXTERNAL ICommand {
 
         struct EXTERNAL IFactory {
@@ -63,7 +62,7 @@ namespace Exchange {
     };
 
     namespace Command {
-
+         
         template <typename COMMAND>
         class FactoryType : public Exchange::ICommand::IFactory {
         private:

--- a/interfaces/IDeviceInfo.h
+++ b/interfaces/IDeviceInfo.h
@@ -21,7 +21,7 @@
 
 #include "Module.h"
 
-// @stubgen:include <com/IRPCIterator.h>
+// @stubgen:include <com/IIteratorType.h>
 
 namespace WPEFramework {
 namespace Exchange {

--- a/interfaces/IDisplayInfo.h
+++ b/interfaces/IDisplayInfo.h
@@ -20,7 +20,7 @@
 #pragma once
 #include "Module.h"
 
-// @stubgen:include <com/IRPCIterator.h>
+// @stubgen:include <com/IIteratorType.h>
 
 namespace WPEFramework {
 namespace Exchange {

--- a/interfaces/IExternalBase.h
+++ b/interfaces/IExternalBase.h
@@ -21,11 +21,11 @@
 #include "Module.h"
 #include "IExternal.h"
 
-// @stubgen:skip
 
 namespace WPEFramework {
 namespace Exchange {
 
+    // @stubgen:omit
     class ExternalBase : public IExternal {
     private:
         class Job { 

--- a/interfaces/IIPNetwork.h
+++ b/interfaces/IIPNetwork.h
@@ -20,11 +20,11 @@
 #pragma once
 #include "Module.h"
 
-// @stubgen:skip
 
 namespace WPEFramework {
 namespace Exchange {
 
+    // @stubgen:omit
     struct EXTERNAL IIPNetwork : virtual public Core::IUnknown {
         enum { ID = ID_IPNETWORK };
 

--- a/interfaces/IMemory.h
+++ b/interfaces/IMemory.h
@@ -20,11 +20,10 @@
 #pragma once
 #include "Module.h"
 
- // @stubgen:skip
-
 namespace WPEFramework {
 namespace Exchange {
 
+    // @stubgen:omit
     // This interface allows for retrieval of memory usage specific to the implementor
     // of the interface
     struct EXTERNAL IMemory : virtual public Core::IUnknown {

--- a/interfaces/IMessenger.h
+++ b/interfaces/IMessenger.h
@@ -21,12 +21,12 @@
 
 #include "Module.h"
 
-// @stubgen:skip
 
 namespace WPEFramework {
 
 namespace Exchange {
 
+ 
 struct IRoomAdministrator : virtual public Core::IUnknown {
     enum { ID = ID_ROOMADMINISTRATOR };
 

--- a/interfaces/IPlayerInfo.h
+++ b/interfaces/IPlayerInfo.h
@@ -21,7 +21,7 @@
 
 #include "Module.h"
 
-// @stubgen:include <com/IRPCIterator.h>
+// @stubgen:include <com/IIteratorType.h>
 
 namespace WPEFramework {
 namespace Exchange {

--- a/interfaces/ISecureShellServer.h
+++ b/interfaces/ISecureShellServer.h
@@ -19,13 +19,14 @@
 
 #pragma once
 
-// @stubgen:skip
+
 
 #include "Module.h"
 
 namespace WPEFramework {
 namespace Exchange {
 
+    // @stubgen:omit
     struct EXTERNAL ISecureShellServer : virtual public Core::IUnknown {
         enum { ID = ID_SECURESHELLSERVER };
 

--- a/interfaces/ISwitchBoard.h
+++ b/interfaces/ISwitchBoard.h
@@ -20,11 +20,11 @@
 #pragma once
 #include "Module.h"
 
-// @stubgen:skip
 
 namespace WPEFramework {
 namespace Exchange {
 
+    // @stubgen:omit
     // This interface gives direct access to a switchboard
     struct EXTERNAL ISwitchBoard : virtual public Core::IUnknown {
         enum { ID = ID_SWITCHBOARD };

--- a/interfaces/ISystemCommands.h
+++ b/interfaces/ISystemCommands.h
@@ -20,11 +20,11 @@
 #pragma once
 #include "Module.h"
 
-// @stubgen:skip
 
 namespace WPEFramework {
 namespace Exchange {
 
+    // @stubgen:omit
     struct EXTERNAL ISystemCommands : virtual public Core::IUnknown {
         enum { ID = ID_SYSTEMCOMMAND };
 

--- a/interfaces/ITimeSync.h
+++ b/interfaces/ITimeSync.h
@@ -20,11 +20,11 @@
 #pragma once
 #include "Module.h"
 
-// @stubgen:skip
 
 namespace WPEFramework {
 namespace Exchange {
 
+    // @stubgen:omit
     // This interface gives direct access to a time synchronize / update
     struct EXTERNAL ITimeSync : virtual public Core::IUnknown {
         enum { ID = ID_TIMESYNC };


### PR DESCRIPTION
I left only one instance of @stubgen:skip in IDRM.h because the parser is not able to parse the content(example use of pointer to pointer type). The parser need to get updated to well parse such interface.