### PR TITLE
Packager plugin should change the state of the downloaded plugin from "Unavailable" to "deactivated"

### DIFF
--- a/interfaces/IPackager.h
+++ b/interfaces/IPackager.h
@@ -49,7 +49,7 @@ namespace Exchange {
             enum { ID = ID_PACKAGER_INSTALLATIONINFO };
             virtual state State() const = 0;
             virtual uint8_t Progress() const = 0;
-	    virtual string AppName() const = 0;
+            virtual string AppName() const = 0;
             virtual uint32_t ErrorCode() const = 0;
             virtual uint32_t Abort() = 0;
         };

--- a/interfaces/IPackager.h
+++ b/interfaces/IPackager.h
@@ -49,6 +49,7 @@ namespace Exchange {
             enum { ID = ID_PACKAGER_INSTALLATIONINFO };
             virtual state State() const = 0;
             virtual uint8_t Progress() const = 0;
+	    virtual string AppName() const = 0;
             virtual uint32_t ErrorCode() const = 0;
             virtual uint32_t Abort() = 0;
         };


### PR DESCRIPTION
Packager plugin should change the state of the downloaded plugin from "Unavailable" to "deactivated" on successful download of the RDM package