### PR TITLE
[UNLOADING] statics in header files and unloading does not go well.

### DIFF
--- a/definitions/Definitions.cpp
+++ b/definitions/Definitions.cpp
@@ -39,7 +39,6 @@
 #include <interfaces/IDolby.h>
 #include <interfaces/IDRM.h>
 #include <interfaces/IDsgccClient.h>
-#include <interfaces/IExternal.h>
 #include <interfaces/IExternalBase.h>
 #include <interfaces/IGuide.h>
 #include <interfaces/IInputPin.h>
@@ -221,6 +220,33 @@ namespace Exchange
     uint32_t IComposition::HeightFromResolution(const IComposition::ScreenResolution resolution)
     {
         return ((static_cast<uint32_t>(resolution) < sizeof(resolutionWidthHeightTable) / sizeof(ScreenResolutionWidthHeight)) ? resolutionWidthHeightTable[static_cast<uint32_t>(resolution)].height : 0);
+    }
+
+    // ------------------------------------------------------------------------
+    // Convenience methods to extract interesting information from the Type()
+    // ------------------------------------------------------------------------
+    /* static */ IExternal::basic IExternal::Basic(const uint32_t instanceType)
+    {
+        return (static_cast<basic>((instanceType >> 12) & 0xF));
+    }
+
+    /* static */ IExternal::dimension IExternal::Dimension(const uint32_t instanceType)
+    {
+        return (static_cast<dimension>((instanceType >> 19) & 0x1FFF));
+    }
+
+    /* static */ IExternal::specific IExternal::Specific(const uint32_t instanceType)
+    {
+        return (static_cast<specific>(instanceType & 0xFFF));
+    }
+
+    /* static */ uint8_t IExternal::Decimals(const uint32_t instanceType)
+    {
+        return ((instanceType >> 16) & 0x07);
+    }
+
+    /* static */ uint32_t IExternal::Type(const IExternal::basic base, const IExternal::specific spec, const IExternal::dimension dim, const uint8_t decimals) {
+        return ((dim << 19) | ((decimals & 0x07) << 16) | (base << 12) | spec);
     }
 }
 }

--- a/definitions/definitions.h
+++ b/definitions/definitions.h
@@ -35,6 +35,7 @@
 #endif
 
 #include <interfaces/IComposition.h>
+#include <interfaces/IExternal.h>
 #include <interfaces/IStream.h>
 #include <interfaces/IVoiceHandler.h>
 #include <interfaces/IPower.h>

--- a/interfaces/IExternal.h
+++ b/interfaces/IExternal.h
@@ -127,25 +127,11 @@ namespace Exchange {
         // ------------------------------------------------------------------------
         // Convenience methods to extract interesting information from the Type()
         // ------------------------------------------------------------------------
-        static basic Basic(const uint32_t instanceType)
-        {
-            return (static_cast<basic>((instanceType >> 12) & 0xF));
-        }
-        static dimension Dimension(const uint32_t instanceType)
-        {
-            return (static_cast<dimension>((instanceType >> 19) & 0x1FFF));
-        }
-        static specific Specific(const uint32_t instanceType)
-        {
-            return (static_cast<specific>(instanceType & 0xFFF));
-        }
-        static uint8_t Decimals(const uint32_t instanceType)
-        {
-            return ((instanceType >> 16) & 0x07);
-        }
-        static uint32_t Type(const basic base, const specific spec, const dimension dim, const uint8_t decimals) {
-            return ((dim << 19) | ((decimals & 0x07) << 16) | (base << 12) | spec);
-        }
+        static basic Basic(const uint32_t instanceType);
+        static dimension Dimension(const uint32_t instanceType);
+        static specific Specific(const uint32_t instanceType);
+        static uint8_t Decimals(const uint32_t instanceType);
+        static uint32_t Type(const basic base, const specific spec, const dimension dim, const uint8_t decimals);
     };
 
 } } // Namespace Exchange


### PR DESCRIPTION
Move the static methods into an implementation file.