### PR TITLE
[IBluetoothAudio] Add latency and delay to the API

### DIFF
--- a/interfaces/IBluetoothAudio.h
+++ b/interfaces/IBluetoothAudio.h
@@ -40,7 +40,7 @@ namespace Exchange {
 
             struct Format {
                 uint32_t SampleRate     /* @brief Source sample rate in Hz (e.g. 44100)*/ ;
-                uint16_t FrameRate      /* @brief Source frame rate in centiseconds (e.g. 2400) */ ;
+                uint16_t FrameRate      /* @brief Source frame rate in cHz (e.g. 2400) */ ;
                 uint8_t Resolution      /* @brief Sampling resolution in bits per sample (e.g. 16) */ ;
                 uint8_t Channels        /* @brief Number of audio channels in the source stream (e.g. 2) */ ;
             };
@@ -71,6 +71,11 @@ namespace Exchange {
             // @param position Current playback position since acquiring the sink (in miliseconds)
             // @retval ERROR_ILLEGAL_STATE The audio sink has not been acquired
             virtual uint32_t Time(uint32_t& position /* @out */) const = 0;
+
+            // @brief Gets current audio delay
+            // @param delay Time for the next audio sample to become audible (in samples)
+            // @retval ERROR_ILLEGAL_STATE The audio sink has not been acquired
+            virtual uint32_t Delay(uint32_t& delay /* @out */) const = 0;
         };
 
         enum state : uint8_t {
@@ -144,6 +149,13 @@ namespace Exchange {
         // @brief Revokes a Bluetooth device from audio playback
         // @retval ERROR_ALREADY_RELEASED No device is currently assigned
         virtual uint32_t Revoke() = 0;
+
+        // @property
+        // @brief Sink audio latency
+        // @param latency Audio latency of the sink in milliseconds (e.g. 20)
+        // @retval ERROR_ILLEGAL_STATE No device is currently assigned
+        virtual uint32_t Latency(const int16_t latency) = 0;
+        virtual uint32_t Latency(int16_t& latency /* @out */) const = 0;
 
         // @property
         // @brief Current audio sink state


### PR DESCRIPTION
Adds two methods:
- Latency - means for a client app to adjust perceived latency, e.g. if a an assigned speaker has unusually high latency
- Delay - means to retrieve current time required for a frame to become audible (includes various factors on the host side, i.e. buffer fill level, compression time, serial baud rate, as well as the configured static sink latency with the Latency property), this is needed for precise A/V sync,
