### PR TITLE
IInputPin: Add pin query interface

### DIFF
--- a/interfaces/IInputPin.h
+++ b/interfaces/IInputPin.h
@@ -35,6 +35,12 @@ namespace Exchange {
             virtual void Marker(const uint32_t marker) = 0;
         };
 
+        struct EXTERNAL ICatalog : virtual public Core::IUnknown {
+            enum { ID = ID_INPUT_PIN_CATALOG };
+
+            virtual IInputPin* IInputPinResource(const uint32_t id) = 0;
+        };
+
         virtual ~IInputPin() { }
 
         virtual void Register(IInputPin::INotification* sink) = 0;

--- a/interfaces/Ids.h
+++ b/interfaces/Ids.h
@@ -142,6 +142,7 @@ namespace Exchange {
 
         ID_INPUT_PIN,
         ID_INPUT_PIN_NOTIFICATION,
+        ID_INPUT_PIN_CATALOG,
 
         ID_MATH,
 


### PR DESCRIPTION
This commit implements a new ICatalog interface in IInputPin to add capability to query a Pin.
This is required to allow plugins to employ the IInputPin interface through json-rpc.