### PR TITLE
RDK-35050: PersistentStore interface

### DIFF
--- a/interfaces/IStore.h
+++ b/interfaces/IStore.h
@@ -21,6 +21,8 @@
 
 #include "Module.h"
 
+// @stubgen:skip
+
 namespace WPEFramework {
 namespace Exchange {
 

--- a/interfaces/IStore.h
+++ b/interfaces/IStore.h
@@ -1,0 +1,52 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "Module.h"
+
+namespace WPEFramework {
+namespace Exchange {
+
+struct EXTERNAL IStore : virtual public Core::IUnknown {
+    enum { ID = ID_STORE };
+
+    struct EXTERNAL INotification : virtual public Core::IUnknown {
+        enum { ID = ID_STORE_NOTIFICATION };
+
+        virtual void ValueChanged(const string &ns, const string &key, const string &value) = 0;
+        virtual void StorageExceeded() = 0;
+    };
+
+    virtual uint32_t Register(Exchange::IStore::INotification *notification) = 0;
+    virtual uint32_t Unregister(Exchange::IStore::INotification *notification) = 0;
+    virtual uint32_t Open(const string &path, const string &key, uint32_t maxSize, uint32_t maxValue) = 0;
+    virtual uint32_t SetValue(const string &ns, const string &key, const string &value) = 0;
+    virtual uint32_t GetValue(const string &ns, const string &key, string &value /* @out */) = 0;
+    virtual uint32_t DeleteKey(const string &ns, const string &key) = 0;
+    virtual uint32_t DeleteNamespace(const string &ns) = 0;
+    virtual uint32_t GetKeys(const string &ns, std::vector<string> &keys /* @out */) = 0;
+    virtual uint32_t GetNamespaces(std::vector<string> &namespaces /* @out */) = 0;
+    virtual uint32_t GetStorageSize(std::map<string, uint64_t> &namespaceSizes /* @out */) = 0;
+    virtual uint32_t FlushCache() = 0;
+    virtual uint32_t Term() = 0;
+};
+
+} // namespace Exchange
+} // namespace WPEFramework

--- a/interfaces/IStoreCache.h
+++ b/interfaces/IStoreCache.h
@@ -24,22 +24,10 @@
 namespace WPEFramework {
 namespace Exchange {
 
-struct EXTERNAL IStore : virtual public Core::IUnknown {
-    enum { ID = ID_STORE };
+struct EXTERNAL IStoreCache : virtual public Core::IUnknown {
+    enum { ID = ID_STORE_CACHE };
 
-    struct EXTERNAL INotification : virtual public Core::IUnknown {
-        enum { ID = ID_STORE_NOTIFICATION };
-
-        virtual void ValueChanged(const string &ns, const string &key, const string &value) = 0;
-        virtual void StorageExceeded() = 0;
-    };
-
-    virtual uint32_t Register(Exchange::IStore::INotification *notification) = 0;
-    virtual uint32_t Unregister(Exchange::IStore::INotification *notification) = 0;
-    virtual uint32_t SetValue(const string &ns, const string &key, const string &value) = 0;
-    virtual uint32_t GetValue(const string &ns, const string &key, string &value /* @out */) = 0;
-    virtual uint32_t DeleteKey(const string &ns, const string &key) = 0;
-    virtual uint32_t DeleteNamespace(const string &ns) = 0;
+    virtual uint32_t FlushCache() = 0;
 };
 
 } // namespace Exchange

--- a/interfaces/Ids.h
+++ b/interfaces/Ids.h
@@ -208,6 +208,9 @@ namespace Exchange {
         ID_DIALSERVER,
         ID_DIALSERVER_APPLICATION,
         ID_ESSOS_SAMPLE,
+
+        ID_STORE,
+        ID_STORE_NOTIFICATION,
     };
 }
 }

--- a/interfaces/Ids.h
+++ b/interfaces/Ids.h
@@ -211,6 +211,7 @@ namespace Exchange {
 
         ID_STORE,
         ID_STORE_NOTIFICATION,
+        ID_STORE_CACHE,
     };
 }
 }


### PR DESCRIPTION
Reason for change: Store can be queried via interface.
Interface for notifications.
Test Procedure: Unit tests.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>