### PR TITLE
RDKTV-11877: timezone interface

### DIFF
--- a/interfaces/ITimeZone.h
+++ b/interfaces/ITimeZone.h
@@ -1,0 +1,43 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "Module.h"
+
+namespace WPEFramework {
+namespace Exchange {
+
+struct EXTERNAL ITimeZone : virtual public Core::IUnknown {
+  enum { ID = ID_TIMEZONE };
+
+  struct EXTERNAL INotification : virtual public Core::IUnknown {
+    enum { ID = ID_TIMEZONE_NOTIFICATION };
+
+    virtual void TimeZoneChanged(const string& timeZone) = 0;
+  };
+
+  virtual uint32_t Register(ITimeZone::INotification* sink) = 0;
+  virtual uint32_t Unregister(ITimeZone::INotification* sink) = 0;
+  virtual uint32_t GetTimeZone(string& timeZone /* @out */) const = 0;
+  virtual uint32_t SetTimeZone(const string& timeZone) = 0;
+};
+
+} // namespace Exchange
+} // namespace WPEFramework

--- a/interfaces/Ids.h
+++ b/interfaces/Ids.h
@@ -208,6 +208,9 @@ namespace Exchange {
         ID_DIALSERVER,
         ID_DIALSERVER_APPLICATION,
         ID_ESSOS_SAMPLE,
+
+        ID_TIMEZONE,
+        ID_TIMEZONE_NOTIFICATION,
     };
 }
 }


### PR DESCRIPTION
Reason for change: ITimeZone interface for
get/set timezone (ex. in a file).
Test Procedure: Builds.
Risks: Low
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>