### PR TITLE
ONEM-22979: OCDM JSONRPC: new ro sessions property and session data type

### DIFF
--- a/jsonrpc/OCDM.json
+++ b/jsonrpc/OCDM.json
@@ -34,6 +34,19 @@
         "name",
         "keysystems"
       ]
+    },
+    "session": {
+      "type": "object",
+      "properties": {
+        "drm": {
+          "type": "string",
+          "description": "name of the DRM system used by the session",
+          "example": "PlayReady"
+        }
+      },
+      "required": [
+        "drm"
+      ]
     }
   },
   "properties": {
@@ -66,6 +79,16 @@
           "$ref": "#/common/errors/badrequest"
         }
       ]
+    },
+    "sessions": {
+      "summary": "Active sessions enumerator",
+      "readonly": true,
+      "params": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/session"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
API to get list of active sessions.

Example usage, lack of active sessions:

    { "jsonrpc": "2.0", "id": 1234567890, "method": "OCDM.1.sessions" }
    < {"jsonrpc":"2.0","id":1234567890,"result":[]}

Example usage, single PlayReady session:

    { "jsonrpc": "2.0", "id": 1234567890, "method": "OCDM.1.sessions" }
    < {"jsonrpc":"2.0","id":1234567890,"result":[{"drm":"PlayReady"}]}

It is safe to upstream that without providing implementation behaves in the following way:

    { "jsonrpc": "2.0", "id": 1234567890, "method": "OCDM.1.sessions" }
    < {"jsonrpc":"2.0","id":1234567890,"error":{"code":-32601,"message":"Unknown method."}}

Implementation will be updated after API update.

Reference for the implementation:
https://github.com/LibertyGlobal/rdkservices/pull/75