### PR TITLE
Onem 22983 api extension for drm initialization r3

### DIFF
--- a/interfaces/IContentDecryption.h
+++ b/interfaces/IContentDecryption.h
@@ -51,8 +51,8 @@ namespace Exchange {
                                               const Status status) = 0;
         };
 
-        virtual uint32_t Register(IContentDecryption::INotification* notification) { return Core::ERROR_NONE; };
-        virtual uint32_t Unregister(IContentDecryption::INotification* notification) { return Core::ERROR_NONE; };
+        virtual uint32_t Register(IContentDecryption::INotification* notification) { return Core::ERROR_NOT_SUPPORTED; };
+        virtual uint32_t Unregister(IContentDecryption::INotification* notification) { return Core::ERROR_NOT_SUPPORTED; };
     };
 
 

--- a/interfaces/IContentDecryption.h
+++ b/interfaces/IContentDecryption.h
@@ -34,6 +34,25 @@ namespace Exchange {
         virtual RPC::IStringIterator* Systems() const = 0;
         virtual RPC::IStringIterator* Designators(const string& keySystem) const = 0;
         virtual RPC::IStringIterator* Sessions(const string& keySystem) const = 0;
+
+        enum Status : uint8_t {
+            BUSY,
+            SUCCESS,
+            FAILED
+        };
+
+        /* @event */
+        struct EXTERNAL INotification : virtual public Core::IUnknown {
+
+            enum {ID = ID_CONTENTDECRYPTION_NOTIFICATION};
+
+            /* @brief initialization status. */
+            virtual void initializationStatus(const std::string& drm,
+                                              const Status status) = 0;
+        };
+
+        virtual uint32_t Register(IContentDecryption::INotification* notification) { return Core::ERROR_NONE; };
+        virtual uint32_t Unregister(IContentDecryption::INotification* notification) { return Core::ERROR_NONE; };
     };
 
 

--- a/interfaces/Ids.h
+++ b/interfaces/Ids.h
@@ -259,6 +259,8 @@ namespace Exchange {
         ID_LISA_KEY_VALUE,
         ID_LISA_KEY_VALUE_ITERATOR,
         ID_LISA_METADATA_PAYLOAD,
+
+        ID_CONTENTDECRYPTION_NOTIFICATION,
     };
 }
 }

--- a/jsonrpc/OCDM.json
+++ b/jsonrpc/OCDM.json
@@ -35,18 +35,27 @@
         "keysystems"
       ]
     },
+    "drmName": {
+      "type": "string",
+      "description": "Name of the DRM system",
+      "example": "PlayReady"
+    },
     "session": {
       "type": "object",
       "properties": {
         "drm": {
-          "type": "string",
-          "description": "name of the DRM system used by the session",
-          "example": "PlayReady"
+          "$ref": "#/definitions/drmName"
         }
       },
       "required": [
         "drm"
       ]
+    },
+    "status": {
+      "description": "BUSY - drm is used by another process, SUCCESS - recovered from BUSY state after retry, FAILED - not recovered after re-trying from BUSY",
+      "type": "string",
+      "enum": [ "BUSY", "SUCCESS", "FAILED"],
+      "example": "SUCCESS"
     }
   },
   "properties": {
@@ -88,6 +97,34 @@
         "items": {
           "$ref": "#/definitions/session"
         }
+      }
+    }
+  },
+  "events": {
+    "drmalreadyinitialized": {
+      "summary": "Signals that the specified DRM system could not be initialized because it is already initialized by another process",
+      "description": "When this event is received, the application owning given DRM system should release it immediately.",
+      "params": {
+        "$ref": "#/definitions/session"
+      }
+    },
+    "drminitializationstatus": {
+      "summary": "Notifies about DRM initialization status",
+      "description": "Register to this event to be notified about DRM retrying status busy/failure/success",
+      "params": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "$ref": "#/definitions/status"
+          },
+          "drm": {
+            "$ref": "#/definitions/drmName"
+          }
+        },
+        "required": [
+          "status",
+          "drm"
+        ]
       }
     }
   }

--- a/jsonrpc/OCDM.json
+++ b/jsonrpc/OCDM.json
@@ -34,6 +34,19 @@
         "name",
         "keysystems"
       ]
+    },
+    "session": {
+      "type": "object",
+      "properties": {
+        "drm": {
+          "type": "string",
+          "description": "name of the DRM system used by the session",
+          "example": "PlayReady"
+        }
+      },
+      "required": [
+        "drm"
+      ]
     }
   },
   "properties": {
@@ -66,6 +79,16 @@
           "$ref": "#/common/errors/badrequest"
         }
       ]
+    },
+    "sessions": {
+      "summary": "Active sessions enumerator",
+      "readonly": true,
+      "params": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/session"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Additional events exposed for OCDM - initialization flow with re-trying:

Example usage drmalreadyinitialized event:

registration:
{"jsonrpc": "2.0","id": 2, "method": "OCDM.1.register","params": { "event": "drmalreadyinitialized", "id" : "OCDM" }}

event:
{"jsonrpc":"2.0","method":"OCDM.drmalreadyinitialized","params":{"drm":"PlayReady"}}

... will be received one time after initialization failed with CDMi::CDMi_RESULT::CDMi_BUSY_CANNOT_INITIALIZE, to make additional actions by external process (release drm resources).
Practical use case is returning DRM_E_BRCM_PLATFORM_ALREADY_INITIALIZED on Broadcom platform)

Example usage drminitializationstatus event:

registration:
{"jsonrpc": "2.0","id": 2, "method": "OCDM.1.register","params": { "event": "drminitializationstatus", "id" : "OCDM" }}

events examples for PlayReady:
{"jsonrpc":"2.0","method":"OCDM.drminitializationstatus","params":{"status":"BUSY","drm":"PlayReady"}}
meaning: PlayReady is BUSY (Playready is used by another process, practical use case is returning DRM_E_BRCM_PLATFORM_ALREADY_INITIALIZED on Broadcom platform)"

{"jsonrpc":"2.0","method":"OCDM.drminitializationstatus","params":{"status":"SUCCESS","drm":"PlayReady"}}
meaning: PlayReady initialized after BUSY and re-trying (SUCCESS):

{"jsonrpc":"2.0","method":"OCDM.drminitializationstatus","params":{"status":"FAILED","drm":"PlayReady"}}
meaning: PlayReady not initialized after BUSY and re-trying (FAILED):

Depending on decision we could keep both events/APIs or keep only the single one.
It is safe to merge API without implementation (stubs provided for COMRPC Register/Unregister methods)

OCDM service implementation will be upstreamed after API synchronization.
After that need to change Register/Unregister methods to pure virtual to make it working.

Reference to the OCDM implementation: https://github.com/LibertyGlobal/rdkservices/pull/77
Contains also changes from: https://github.com/rdkcentral/ThunderInterfaces/pull/144 (small json API definition refactoring happens here)