### PR TITLE
IPower: update the StateChange callback function to have more context

### DIFF
--- a/interfaces/IPower.h
+++ b/interfaces/IPower.h
@@ -35,10 +35,21 @@ namespace Exchange {
             PowerOff = 6, // S5.
         };
 
+        enum PCPhase : uint8_t {
+            Before = 1,
+            After  = 2
+        };
+
+        struct PowerState {
+            PCState origin;
+            PCState destination;
+            PCPhase phase;
+        };
+
         struct EXTERNAL INotification : virtual public Core::IUnknown {
             enum { ID = ID_POWER_NOTIFICATION };
 
-            virtual void StateChange(const PCState) = 0;
+            virtual void StateChange(const PowerState &state) = 0;
         };
 
         virtual void Register(IPower::INotification* sink) = 0;


### PR DESCRIPTION
This commit is for changing the callback function to notify the power
state change to have more context.
A new struct 'PowerState' is introduced which will have the details of
previous power state, new power state and the phase(Before/After).
PowerState instance is passed as an argument for StateChange().
This change helps to send before and after power state change notification.
It also helps the observers to take necessary actions depending on the previous/current state.