### PR TITLE
RDKDEV-257: IPower: Update StateChange callback function to have more context

### DIFF
--- a/interfaces/IPower.h
+++ b/interfaces/IPower.h
@@ -35,10 +35,15 @@ namespace Exchange {
             PowerOff = 6, // S5.
         };
 
+        enum PCPhase : uint8_t {
+            Before = 1,
+            After  = 2
+        };
+
         struct EXTERNAL INotification : virtual public Core::IUnknown {
             enum { ID = ID_POWER_NOTIFICATION };
 
-            virtual void StateChange(const PCState) = 0;
+            virtual void StateChange(const PCState origin, const PCState destination, const PCPhase phase) = 0;
         };
 
         virtual void Register(IPower::INotification* sink) = 0;


### PR DESCRIPTION


This commit adds more context to the callback function that notify the power state change events.
In addition to the new power state, the current power state and
the phase of transition (Before/After) is also included in parameters.
This change helps to send "Before" and "After" power state change notification.

v1(https://github.com/rdkcentral/ThunderInterfaces/pull/163) ->v2

- Modified StateChange() callback parameters to send out the values separately instead of using `struct PowerState`