### PR TITLE
RDK-37251: Thunder R2-v1.11 upgrade (Bug Fixes)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,9 +19,9 @@ cmake_minimum_required(VERSION 3.12)
 
 project(WPEFramework)
 
-set(VERSION_MAJOR 1)
-set(VERSION_MINOR 0)
-set(VERSION_PATCH 0)
+set(VERSION_MAJOR 2)
+set(VERSION_MINOR 1)
+set(VERSION_PATCH 11)
 
 set(VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH})
 set(NAMESPACE ${PROJECT_NAME} CACHE STRING "Namespace of the project")


### PR DESCRIPTION
Reason for change: Bumped libraries version to 2.1.11

Test Procedure: Build and verify.
Risks: Low
Signed-off-by:Zameerun Rasheed M S zexpen@gmail.com