### PR TITLE
Extend IWebBrowser interface for XRE/X1 usecases

### DIFF
--- a/interfaces/IBrowser.h
+++ b/interfaces/IBrowser.h
@@ -201,5 +201,43 @@ namespace Exchange {
         virtual uint32_t MixedContentPolicy(MixedContentPolicyType& policy /* @out */) const = 0;
         virtual uint32_t MixedContentPolicy(const MixedContentPolicyType policy) = 0;
     };
+
+    /* @json */
+    struct EXTERNAL IBrowserScripting : virtual public Core::IUnknown {
+        enum { ID = ID_BROWSER_SCRIPTING };
+
+        // @brief Run javascript in main frame.
+        // @param script Utf8 encoded JS code string.
+        virtual uint32_t RunJavaScript(const string& script) = 0;
+
+        // @brief Add user script to be executed at document start.
+        // @param script Utf8 encoded JS code string.
+        virtual uint32_t AddUserScript(const string& script, const bool topFrameOnly) = 0;
+
+        // @brief Remove all user scripts.
+        virtual uint32_t RemoveAllUserScripts() = 0;
+    };
+
+    /* @json */
+    struct EXTERNAL IBrowserCookieJar : virtual public Core::IUnknown {
+        enum { ID = ID_BROWSER_COOKIEJAR };
+
+        /* @event */
+        struct INotification : virtual public Core::IUnknown {
+            enum { ID = ID_BROWSER_COOKIEJAR_NOTIFICATION };
+
+            // @brief Notifies that cookies were added, removed or modified.
+            virtual void CookieJarChanged() = 0;
+        };
+
+        virtual void Register(INotification* sink) = 0;
+        virtual void Unregister(INotification* sink) = 0;
+
+        /* @json:omit */
+        virtual uint32_t CookieJar(uint32_t& version /* @out */, uint32_t& checksum /* @out */, string& payload /* @out */) const = 0;
+        /* @json:omit */
+        virtual uint32_t CookieJar(const uint32_t version, const uint32_t checksum, const string& payload) = 0;
+    };
+
 }
 }

--- a/interfaces/IBrowser.h
+++ b/interfaces/IBrowser.h
@@ -202,7 +202,7 @@ namespace Exchange {
         virtual uint32_t MixedContentPolicy(const MixedContentPolicyType policy) = 0;
     };
 
-    /* @json */
+    /* @json @uncompliant:extended */
     struct EXTERNAL IBrowserScripting : virtual public Core::IUnknown {
         enum { ID = ID_BROWSER_SCRIPTING };
 

--- a/interfaces/Ids.h
+++ b/interfaces/Ids.h
@@ -56,6 +56,9 @@ namespace Exchange {
         ID_BROWSER_RESOURCES                       = ID_BROWSER + 4,
         ID_BROWSER_SECURITY                        = ID_BROWSER + 5,
         ID_WEBKITBROWSER_NOTIFICATION              = ID_BROWSER + 6,
+        ID_BROWSER_SCRIPTING                       = ID_BROWSER + 7,
+        ID_BROWSER_COOKIEJAR                       = ID_BROWSER + 8,
+        ID_BROWSER_COOKIEJAR_NOTIFICATION          = ID_BROWSER + 9,
 
         ID_POWER                                   = 0x00000050,
         ID_POWER_NOTIFICATION                      = ID_POWER + 1,

--- a/jsonrpc/CookieJar.json
+++ b/jsonrpc/CookieJar.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "interface.schema.json",
+  "jsonrpc": "2.0",
+  "info": {
+    "class": "BrowserCookieJar",
+    "title": "Browser CookieJar API",
+    "description": "Browser CookieJar JSON-RPC interface"
+  },
+  "properties": {
+    "cookiejar": {
+      "summary": "User preferred languages",
+      "params": {
+        "type": "object",
+        "properties": {
+          "version": {
+            "description": "Version of payload format",
+            "type": "integer"
+          },
+          "checksum": {
+            "description": "The checksum of the string used for payload creation",
+             "type": "integer"
+          },
+          "payload": {
+            "description": "Base64 string representation of compressed and encrypted cookies",
+            "type": "string"
+          }
+        },
+        "required": [
+          "version",
+          "checksum",
+          "payload"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds API to 

- run JS code in web page main frame
- add/remove users scripts 
- needed support for "cloud" cookie jar