### PR TITLE
REFPLTV-942: In ThunderInterfaces, missing MPEG2 and MPEG4 in Video c…

### DIFF
--- a/interfaces/IPlayerInfo.h
+++ b/interfaces/IPlayerInfo.h
@@ -52,6 +52,8 @@ namespace Exchange {
             VIDEO_H265,
             VIDEO_H265_10,
             VIDEO_MPEG,
+            VIDEO_MPEG2,
+            VIDEO_MPEG4,
             VIDEO_VP8,
             VIDEO_VP9,
             VIDEO_VP10


### PR DESCRIPTION
…odecs

Reason for change: Added MPEG2 and MPEG4 in supported Video codecs list

Test Procedure: curl command for PlayerInfo.1.videocodecs should return MPEG2 and MPEG4 values.

Risks: Low

Signed-off-by: dmayil759 <deepa_mayilsamy@comcast.com>