### PR TITLE
RDK-37628 Added IRustBridge interface

### DIFF
--- a/definitions/Definitions.cpp
+++ b/definitions/Definitions.cpp
@@ -56,6 +56,7 @@
 #include <interfaces/IResourceMonitor.h>
 #include <interfaces/IRPCLink.h>
 #include <interfaces/IRtspClient.h>
+#include <interfaces/IRustBridge.h>
 #include <interfaces/ISecureShellServer.h>
 #include <interfaces/IStream.h>
 #include <interfaces/ISwitchBoard.h>

--- a/interfaces/IRustBridge.h
+++ b/interfaces/IRustBridge.h
@@ -1,0 +1,67 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+#pragma once
+
+#include "Module.h"
+
+namespace WPEFramework {
+
+	namespace Exchange {
+
+		struct EXTERNAL IRustBridge : virtual public Core::IUnknown {
+			
+			enum { ID = ID_RUST_BRIDGE };
+
+			struct EXTERNAL ICallback : virtual public Core::IUnknown {
+				
+				enum { ID = ID_RUST_BRIDGE_NOTIFICATION };
+				
+				~ICallback() override = default;
+
+				// ALLOW RUST -> THUNDER (Invoke and Event)
+				// The synchronous Invoke from a JSONRPC is coming from the RUST world,
+				// synchronously handle this in the Thunder world.
+				virtual void Invoke(const string& context, const string& method, const string& parmeters, string& response /* @out */, uint32_t& result /* @out */) = 0;
+				
+				// Allow RUST to send an event to the interested subscribers in the Thunder
+				// world.
+				virtual void Event(const string& event, const string& parmeters) = 0;
+
+				// This is the response form the RUST side of things for the Request that was send..
+				virtual void Response(const uint32_t id, const string& response, const uint32_t error) = 0;
+			};
+
+			~IRustBridge() override = default;		
+			
+			virtual uint32_t Configure(PluginHost::IShell* framework, ICallback* callback) = 0;
+			
+			// ALLOW THUNDER -> RUST (Invoke and Event)
+			// The synchronous Invoke from a JSONRPC perspective has been splitup into an 
+			// a-synchronous communication to RUST. First we send a Request with an id,
+			// Than it is up to RUST (ICallback) to send a response (with the same id) to 
+			// complete.
+			virtual void Request(const uint32_t id, const string& context, const string& method, const string& parmeters) = 0;
+			
+			// Allow THUNDER to send an event to the interested subscribers in the RUST
+			// world.
+			virtual void Event(const string& event, const string& parmeters) = 0;
+		};
+	}
+} // Namespace Exchange

--- a/interfaces/Ids.h
+++ b/interfaces/Ids.h
@@ -243,6 +243,8 @@ namespace Exchange {
         ID_LISA_LOCK_INFO,
         ID_LISA_HANDLE_RESULT,
 
+        ID_RUST_BRIDGE                             = 0x000004B0,
+        ID_RUST_BRIDGE_NOTIFICATION                = ID_RUST_BRIDGE + 1,
         ID_CONTENTDECRYPTION_NOTIFICATION,
         
 	ID_WATERMARK,

--- a/interfaces/Interfaces.vcxproj
+++ b/interfaces/Interfaces.vcxproj
@@ -89,6 +89,7 @@
     <ClInclude Include="IProvisioning.h" />
     <ClInclude Include="IRPCLink.h" />
     <ClInclude Include="IRtspClient.h" />
+    <ClInclude Include="IRustBridge.h" />
     <ClInclude Include="IStream.h" />
     <ClInclude Include="ISwitchBoard.h" />
     <ClInclude Include="ISystemCommands.h" />

--- a/interfaces/Interfaces.vcxproj.filters
+++ b/interfaces/Interfaces.vcxproj.filters
@@ -236,6 +236,9 @@
     <ClInclude Include="definitions.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="IRustBridge.h">
+      <Filter>Interface Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="DataModel.json" />


### PR DESCRIPTION
This commits adds interface required by RustBridge. Rust bridge was originally part of ThunderNanoServices but we want to make it part of rdkservices and for it to replace RustAdapter.

This relates to rdkservices pull request https://github.com/rdkcentral/rdkservices/pull/3331 