### PR TITLE
[CLEANUP] Removing dependencies to Tracing (if appplicable)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,19 +18,9 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(Interfaces)
-find_package(WPEFramework)
-
-project_version(1.0.0)
 
 set(INTERFACES_PATTERNS "I*.h" CACHE STRING "Patterns matching files for which stubs should be generated")
 set(JSONRPC_PATTERNS "*.json" CACHE STRING "Patterns matching files for which json stubs should be generated")
-
-message(STATUS "Setting up ${PROJECT_NAME} v${PROJECT_VERSION}")
-
-find_package(CompileSettingsDebug CONFIG REQUIRED)
-find_package(${NAMESPACE}Core)
-find_package(${NAMESPACE}Tracing)
-find_package(${NAMESPACE}COM)
 
 if (BUILD_REFERENCE)
     add_definitions (-DBUILD_REFERENCE=${BUILD_REFERENCE})

--- a/definitions/CMakeLists.txt
+++ b/definitions/CMakeLists.txt
@@ -14,9 +14,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-find_package(JsonGenerator REQUIRED)
 
-set(Target ${NAMESPACE}Definitions)
+cmake_minimum_required(VERSION 3.3)
+
+project(Definitions)
+
+find_package(WPEFramework)
+
+project_version(1.0.0)
+
+find_package(CompileSettingsDebug REQUIRED)
+find_package(JsonGenerator REQUIRED)
+find_package(${NAMESPACE}Core REQUIRED)
+
+set(Target ${NAMESPACE}${PROJECT_NAME})
 
 separate_arguments(JSONRPC_PATTERNS)
 list(TRANSFORM JSONRPC_PATTERNS PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/../jsonrpc/")
@@ -50,10 +61,8 @@ add_library(${Target} SHARED
         )
 
 target_link_libraries(${Target}
-        PUBLIC
-          ${NAMESPACE}Core::${NAMESPACE}Core
-          ${NAMESPACE}Tracing::${NAMESPACE}Tracing
         PRIVATE
+          ${NAMESPACE}Core::${NAMESPACE}Core
           CompileSettingsDebug::CompileSettingsDebug
         )
 
@@ -67,7 +76,7 @@ set_target_properties(${Target} PROPERTIES
         )
 
 target_include_directories(${Target}
-        PUBLIC
+        PRIVATE
           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
           $<INSTALL_INTERFACE:include/${NAMESPACE}>

--- a/interfaces/CMakeLists.txt
+++ b/interfaces/CMakeLists.txt
@@ -15,9 +15,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find_package(ProxyStubGenerator REQUIRED)
+cmake_minimum_required(VERSION 3.3)
 
-set(TargetMarshalling ${NAMESPACE}Marshallings)
+project(Marshalling)
+
+find_package(WPEFramework)
+
+project_version(1.0.0)
+
+find_package(CompileSettingsDebug REQUIRED)
+find_package(ProxyStubGenerator REQUIRED)
+find_package(${NAMESPACE}Core REQUIRED)
+find_package(${NAMESPACE}COM REQUIRED)
+
+set(Target ${NAMESPACE}${PROJECT_NAME})
 
 if(NOT GENERATOR_SEARCH_PATH)
     set(GENERATOR_SEARCH_PATH ${CMAKE_SYSROOT}${CMAKE_INSTALL_PREFIX}/include/${NAMESPACE})
@@ -34,21 +45,21 @@ list(APPEND INTERFACES_HEADERS Portability.h)
 list(APPEND INTERFACES_HEADERS Module.h)
 
 file(GLOB PROXY_STUB_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/generated/ProxyStubs*.cpp")
-add_library(${TargetMarshalling} SHARED
+add_library(${Target} SHARED
         Module.cpp
         ${PROXY_STUB_SOURCES}
         )
 
-target_include_directories(${TargetMarshalling} PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/..)
+target_include_directories(${Target} PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/..)
 
-target_link_libraries(${TargetMarshalling}
+target_link_libraries(${Target}
         PRIVATE
           ${NAMESPACE}Core::${NAMESPACE}Core
           ${NAMESPACE}COM::${NAMESPACE}COM
           CompileSettingsDebug::CompileSettingsDebug
         )
 
-set_target_properties(${TargetMarshalling} PROPERTIES
+set_target_properties(${Target} PROPERTIES
         CXX_STANDARD 11
         CXX_STANDARD_REQUIRED YES
         FRAMEWORK FALSE
@@ -59,7 +70,7 @@ set_target_properties(${TargetMarshalling} PROPERTIES
 string(TOLOWER ${NAMESPACE} NAMESPACE_LIB)
 
 install(
-        TARGETS ${TargetMarshalling} EXPORT ${TargetMarshalling}Targets  # for downstream dependencies
+        TARGETS ${Target} EXPORT ${Target}Targets  # for downstream dependencies
         LIBRARY DESTINATION lib/${NAMESPACE_LIB}/proxystubs COMPONENT libs      # shared lib
 )
 


### PR DESCRIPTION
          Making the linking libraries PROVATE to avoid implementation leakage.