### PR TITLE
Cherrypick RDK-42766:Changes on TTS thunder plugin for Supporting speechrate (#264) to R2

### DIFF
--- a/interfaces/ITextToSpeech.h
+++ b/interfaces/ITextToSpeech.h
@@ -79,6 +79,7 @@ namespace Exchange {
         virtual uint32_t SetFallbackText(const string scenario,const string value) = 0;
         virtual uint32_t SetAPIKey(const string apikey) = 0;
         virtual uint32_t SetPrimaryVolDuck(const uint8_t prim) = 0;
+        virtual uint32_t SetSpeechRate(const string speechRate) = 0;
 
         // @brief Retrieve tts configuration attributes 
         // @param config tts configuration


### PR DESCRIPTION
Reason for change: User story RDK-42281
Test Procedure: Mentioned in ticket
Risks: Low