### PR TITLE
[Messaging] Using the enum from Core::Messaging::Metadata in interfaces

### DIFF
--- a/interfaces/IMessageControl.h
+++ b/interfaces/IMessageControl.h
@@ -21,6 +21,7 @@
 
 #include "Module.h"
 
+// @insert <core/MessageStore.h>
 // @insert <com/IIteratorType.h>
 
 namespace WPEFramework {
@@ -32,13 +33,7 @@ struct EXTERNAL IMessageControl : virtual public Core::IUnknown {
 
     enum { ID = ID_MESSAGE_CONTROL };
 
-    enum messagetype : uint8_t {
-        TRACING        = 1,
-        LOGGING        = 2,
-        REPORTING      = 3,
-        STANDARD_OUT   = 4,
-        STANDARD_ERROR = 5
-    };
+    using messagetype = Core::Messaging::Metadata::type;
 
     struct Control {
         messagetype type /* @brief Type of message */;


### PR DESCRIPTION
It needs this PR merged first to work: https://github.com/rdkcentral/Thunder/pull/1377