### PR TITLE
DELIA-62843:TTS thunder plugin missing "speechrate" attribute

### DIFF
--- a/interfaces/ITextToSpeech.h
+++ b/interfaces/ITextToSpeech.h
@@ -14,6 +14,7 @@ namespace Exchange {
             std::string ttsEndPointSecured;
             std::string language;
             std::string voice;
+            std::string speechRate;
             uint8_t volume;
             uint8_t rate;
         };
@@ -79,7 +80,6 @@ namespace Exchange {
         virtual uint32_t SetFallbackText(const string scenario,const string value) = 0;
         virtual uint32_t SetAPIKey(const string apikey) = 0;
         virtual uint32_t SetPrimaryVolDuck(const uint8_t prim) = 0;
-        virtual uint32_t SetSpeechRate(const string speechRate) = 0;
 
         // @brief Retrieve tts configuration attributes 
         // @param config tts configuration


### PR DESCRIPTION
Reason for change: TTS thunder plugin missing "speechrate"
Test Procedure: Mentioned in ticket
Risks: Low