### PR TITLE
REFPLTV-1561 - Added support for RPI for modelname, devicetype, make …

### DIFF
--- a/jsonrpc/DeviceInfo.json
+++ b/jsonrpc/DeviceInfo.json
@@ -335,7 +335,9 @@
       "enum": [
         "tv",
         "IpStb",
-        "QamIpStb"
+        "QamIpStb",
+        "hybrid",
+        "mediaclient"
       ],
       "description": "Device type",
       "example": "IpStb"
@@ -355,7 +357,8 @@
         "pace",
         "samsung",
         "technicolor",
-        "Amlogic_Inc"
+        "Amlogic_Inc",
+        "raspberrypi_org"
       ],
       "description": "Device manufacturer",
       "example": "pace"
@@ -389,7 +392,8 @@
         "PX051AEI",
         "PXD01ANI",
         "SX022AN",
-        "TX061AEI"
+        "TX061AEI",
+        "PI"
       ],
       "description": "Device model number or SKU",
       "example": "PX051AEI"


### PR DESCRIPTION

REFPLTV-1561 RDKServices: Some of the APIs in DeviceInfo plugin are returning ERROR_GENERAL message

Reason for change: Support is added for RPI.
Test Procedure: Ensure the DeviceInfo plugin functionality for modelname, make, devicetype and modelid properties.
Risks: low.
Signed-off-by: SajjadMusa_Shaikh@comcast.com