### PR TITLE
Update IPlayerInfo.h

### DIFF
--- a/interfaces/IPlayerInfo.h
+++ b/interfaces/IPlayerInfo.h
@@ -107,7 +107,25 @@ namespace Exchange {
             RESOLUTION_2160P30,
             RESOLUTION_2160P50,
             RESOLUTION_2160P60,
-            RESOLUTION_2160P
+            RESOLUTION_2160P,
+            RESOLUTION_600P24,
+            RESOLUTION_600P25,
+            RESOLUTION_600P30,
+            RESOLUTION_600P50,
+            RESOLUTION_600P60,
+            RESOLUTION_600P,
+            RESOLUTION_768P24,
+            RESOLUTION_768P25,
+            RESOLUTION_768P30,
+            RESOLUTION_768P50,
+            RESOLUTION_768P60,
+            RESOLUTION_768P,
+            RESOLUTION_3840x1080P24,
+            RESOLUTION_3840x1080P25,
+            RESOLUTION_3840x1080P30,
+            RESOLUTION_3840x1080P50,
+            RESOLUTION_3840x1080P60,
+            RESOLUTION_3840x1080P
         };
 
         // @property


### PR DESCRIPTION
chnages only for R2 branch  RDK-43929 New Resoultion headers update for 600p, 768p, 3840x1080p 