### PR TITLE
ES1-631 TTS Thunder interface change

### DIFF
--- a/interfaces/ITextToSpeech.h
+++ b/interfaces/ITextToSpeech.h
@@ -65,6 +65,7 @@ namespace Exchange {
 
         virtual void Register(ITextToSpeech::INotification* sink) = 0;
         virtual void Unregister(ITextToSpeech::INotification* sink) = 0;
+        virtual void RegisterWithCallsign(const string callsign,ITextToSpeech::INotification* sink) = 0;
         
         // @property
         // @brief Query the status/enable tts


### PR DESCRIPTION
Reason for change: TTS plugin to support callsign based registeration
Test Procedure: Mentioned in ticket
Risks: Low