### PR TITLE
RTD131X-1115 - DAB - Required platform support is not met

### DIFF
--- a/jsonrpc/DeviceInfo.json
+++ b/jsonrpc/DeviceInfo.json
@@ -303,7 +303,12 @@
         "samsung",
         "technicolor",
         "Amlogic_Inc",
-        "raspberrypi_org"
+        "raspberrypi_org",
+	"realtek",
+	"Skyworth",
+	"RDKCommonPort",
+	"BRCMREF",
+	"SAGEMCOM"
       ],
       "description": "Device manufacturer",
       "example": "pace"
@@ -342,7 +347,16 @@
         "XUSHTC11MWR",
         "XUSPTC11MWR",
         "XUSHTB11MWR",
-        "PITU11MWR"
+        "PITU11MWR",
+	"HP44H",
+	"AH212",
+	"AT301",
+	"BLADE",
+	"REALTEKHANK",
+	"M39372180ZBSTB",
+	"BCM972180HB",
+	"BRCMREF",
+	"BCM972126OTT"
       ],
       "description": "Device model number or SKU",
       "example": "PX051AEI"


### PR DESCRIPTION
Reason for change: Adding missing VA make type and manufacturer info

Test Procedure: Build and verify

Risks: Low