### PR TITLE
RDKTV-29897 : Add missing make, yocto Ids

### DIFF
--- a/jsonrpc/DeviceInfo.json
+++ b/jsonrpc/DeviceInfo.json
@@ -303,7 +303,8 @@
         "samsung",
         "technicolor",
         "Amlogic_Inc",
-        "raspberrypi_org"
+        "raspberrypi_org",
+        "Pioneer"
       ],
       "description": "Device manufacturer",
       "example": "pace"
@@ -352,7 +353,8 @@
       "enum": [
         "dunfell",
         "morty",
-        "daisy"
+        "daisy",
+        "kirkstone"
       ],
       "description": "Yocto version",
       "example": "dunfell"


### PR DESCRIPTION
Reason for change: "Manufacturer" name is empty in pioneer 2K
Test Procedure: None
Risks: None
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>