### PR TITLE
RDKTV-31447 LlamaGlass make name shows Amlogic_Inc

### DIFF
--- a/jsonrpc/DeviceInfo.json
+++ b/jsonrpc/DeviceInfo.json
@@ -347,6 +347,7 @@
         "llama",
         "hisense",
         "element",
+	"Sky_CP",
         "sky",
         "sercomm",
         "commscope",


### PR DESCRIPTION
Reason for change: return Sky_CP instead of Amlogic_Inc
Test Procedure: None
Risks: None
Signed-off-by: ramkumar_prabaharan ramkumar_prabaharan@comcast.com

Change-Id: I9097043bf6229dc5497b2bb4602dde527362166e