### PR TITLE
RDK-50751: Remove HDCPProfile and move the APIs DisplayInfo

### DIFF
--- a/interfaces/IDisplayInfo.h
+++ b/interfaces/IDisplayInfo.h
@@ -116,6 +116,51 @@ namespace Exchange {
         // @param name: video output port name
         virtual uint32_t PortName (string& name /* @out */) const = 0;
 
+        // @property
+        // @brief The status 'HDCP compliant' will return true 
+        // if the display device is connected and HDCP is in an 
+        // authenticated state. The internal display is intended
+        //  for sink devices (TVs), while the connected display 
+        //  device is for streaming source devices (STBs).
+        // @param isHDCPCompliant: compliant/ non compliant
+        virtual uint32_t IsHDCPCompliant(bool& isHDCPCompliant /* @out */) const = 0;
+
+        // @property
+        // @brief This status indicates whether HDCP 
+        // is enabled in the software stack. Typically, 
+        // HDCP is enabled by default on all devices 
+        // but can be disabled by setting a software flag.
+        // @param isHDCPEnabled: enabled/not enabled
+        virtual uint32_t IsHDCPEnabled(bool& isHDCPEnabled /* @out */) const = 0;
+
+        // @property
+        // @brief This field indicates the HDCP support status, 
+        // serving as a static indicator for HDCP compatibility. 
+        // HDCP support is enabled by default on all RDK devices, 
+        // ensuring compatibility with protected content.
+        // @param isHDCPSupported: supported/not supported
+        virtual uint32_t IsHDCPSupported(bool& isHDCPSupported /* @out */) const = 0;
+
+        // @property
+        // @brief Gets hdcp status reason as integer status code
+        // @param hdcpReason: hdcp status reason as intiger status code
+        virtual uint32_t HdcpReason(uint32_t& hdcpReason /* @out */) const = 0;
+
+        // @property
+        // @brief The supported HDCP version refers to the HDCP version of the host device.
+        // @param value: protocol
+        virtual uint32_t SupportedHDCPVersion (HDCPProtectionType& value /* @out */) const = 0;
+
+        // @property
+        // @brief Display HDCP version
+        // @param value: protocol
+        virtual uint32_t DisplayHDCPVersion (HDCPProtectionType& value /* @out */) const = 0;
+
+        // @property
+        // @brief Current HDCP version
+        // @param value: protocol
+        virtual uint32_t CurrentHDCPVersion (HDCPProtectionType& value /* @out */) const = 0;
+
     };
 
     /* @json */

--- a/jsonrpc/DisplayInfo.json
+++ b/jsonrpc/DisplayInfo.json
@@ -58,6 +58,45 @@
             "type": "string",
             "enum": [ "HDROff", "HDR10", "HDR10Plus", "HDRDolbyVision", "HDRTechnicolor" ],
             "example": "HDROff"
+          },
+          "ishdcpcompliant": {
+            "description": "The status 'HDCP compliant' will return true if the display device is connected and HDCP is in an authenticated state. The internal display is intended for sink devices (TVs), while the connected display device is for streaming source devices (STBs).",
+            "type": "boolean",
+            "example": true
+          },
+          "ishdcpenabled": {
+            "description": "This status indicates whether HDCP is enabled in the software stack. Typically, HDCP is enabled by default on all devices but can be disabled by setting a software flag.",
+            "type": "boolean",
+            "example": true
+          },
+          "ishdcpsupported": {
+            "description": "This field indicates the HDCP support status, serving as a static indicator for HDCP compatibility. HDCP support is enabled by default on all RDK devices, ensuring compatibility with protected content.",
+            "type": "boolean",
+            "example": true
+          },
+          "hdcpreason": {
+            "description": "Gets hdcp status reason as integer status code",
+            "type": "number",
+            "size": 32,
+            "example": 0
+          },
+          "supportedhdcpversion": {
+            "description": "The supported HDCP version refers to the HDCP version of the host device.",
+            "type": "string",
+            "enum": [ "Unencrypted", "HDCP1x", "HDCP2x"],
+            "example": "HDCP1x"
+          },
+          "displayhdcpversion": {
+            "description": "The 'Display HDCP version' refers to different HDCP versions depending on the device context: for the source device (STB), it indicates the HDCP version of the connected display, whereas for the sink device (TV), it will be the same HDCP version of the host device",
+            "type": "string",
+            "enum": [ "Unencrypted", "HDCP1x", "HDCP2x"],
+            "example": "HDCP1x"
+          },
+          "currenthdcpversion": {
+            "description": "The 'Current HDCP version' refers to the HDCP version determined based on the capabilities of both the host device and the connected display.",
+            "type": "string",
+            "enum": [ "Unencrypted", "HDCP1x", "HDCP2x"],
+            "example": "HDCP1x"
           }
         },
         "required": [
@@ -68,7 +107,14 @@
           "width",
           "height",
           "hdcpprotection",
-          "hdrtype"
+          "hdrtype",
+          "ishdcpcompliant",
+          "ishdcpenabled",
+          "ishdcpsupported",
+          "hdcpreason",
+          "supportedhdcpversion",
+          "receiverhdcpversion",
+          "currenthdcpversion"
         ]
       }
     }


### PR DESCRIPTION
Reason for change:
Remove HDCPProfile and move the APIs DisplayInfo

Test Procedure: None
Risks: Low

Change-Id: I56080638cd4c2b85142896ee2aaa79d8ef713cc0 Signed-off-by:Anooj Cheriyan <Anooj_Cheriyan@comcast.com>