### PR TITLE
DELIA-66115: ScopeType enum case

### DIFF
--- a/interfaces/IStore2.h
+++ b/interfaces/IStore2.h
@@ -33,8 +33,8 @@ namespace Exchange {
         ~IStore2() override = default;
 
         enum ScopeType : uint8_t {
-            DEVICE,
-            ACCOUNT
+            DEVICE /* @text:device */,
+            ACCOUNT /* @text:account */
         };
 
         // @event


### PR DESCRIPTION
Reason for change: Lowercase for consistency with previous json spec.
Test Procedure: None
Risks: None
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>