### PR TITLE
DELIA-66154: Some DeviceInfo properties are returning "ERROR_GENERAL"…

### DIFF
--- a/jsonrpc/DeviceInfo.json
+++ b/jsonrpc/DeviceInfo.json
@@ -355,7 +355,8 @@
         "pace",
         "samsung",
         "technicolor",
-        "Amlogic_Inc"
+        "Amlogic_Inc",
+        "TPV"
       ],
       "description": "Device manufacturer",
       "example": "pace"
@@ -363,6 +364,7 @@
     "sku": {
       "type": "string",
       "enum": [
+        "PITU11MWR",
         "PLTL11AEI",
         "ZWCN11MWI",
         "SKTL11AEI",
@@ -397,6 +399,7 @@
     "yocto": {
       "type": "string",
       "enum": [
+        "kirkstone",
         "dunfell",
         "morty",
         "daisy"


### PR DESCRIPTION
… and results are inconsistent across Xumo platforms

Reason for change: DeviceInfo properties are returning "ERROR_GENERAL" Error: DeviceInfo properties are returning "ERROR_GENERAL" Test Procedure: Verify the DeviceInfo properties response Risks: Low
Signed-off-by:AkshayKumar_Gampa <AkshayKumar_Gampa@comcast.com>