### PR TITLE
DELIA-66154: Some DeviceInfo properties are returning "ERROR_GENERAL"…

### DIFF
--- a/jsonrpc/DeviceInfo.json
+++ b/jsonrpc/DeviceInfo.json
@@ -311,7 +311,8 @@
         "technicolor",
         "Amlogic_Inc",
         "raspberrypi_org",
-        "Pioneer"
+        "Pioneer",
+        "TPV"
       ],
       "description": "Device manufacturer",
       "example": "pace"


### PR DESCRIPTION
… and results are inconsistent across Xumo platforms

Reason for change: DeviceInfo properties are returning "ERROR_GENERAL" Error: DeviceInfo properties are returning "ERROR_GENERAL" Test Procedure: Verify the DeviceInfo properties response Risks: Low
Signed-off-by:AkshayKumar_Gampa <AkshayKumar_Gampa@comcast.com>