### PR TITLE
REFPLTV-1561: RDKServices: Some of the APIs in DeviceInfo plugin are returning ERROR_GENERAL message

### DIFF
--- a/jsonrpc/DeviceInfo.json
+++ b/jsonrpc/DeviceInfo.json
@@ -359,7 +359,8 @@
         "Amlogic_Inc",
         "raspberrypi_org",
         "Pioneer",
-        "TPV"
+        "TPV",
+	"RaspberryPi4"
       ],
       "description": "Device manufacturer",
       "example": "pace"
@@ -398,7 +399,8 @@
         "XUSHTC11MWR",
         "XUSPTC11MWR",
         "XUSHTB11MWR",
-        "PITU11MWR"
+        "PITU11MWR",
+	"RPi4"
       ],
       "description": "Device model number or SKU",
       "example": "PX051AEI"


### PR DESCRIPTION
Reason for change: Adding the changes to get modelid and make
Test Procedure: build and verify.
Risks: low
Signed-off-by: Dorababu_Pragada@comcast.com

