### PR TITLE
RDK-52316 : Copyright fix

### DIFF
--- a/interfaces/IContentProtection.h
+++ b/interfaces/IContentProtection.h
@@ -2,7 +2,7 @@
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
- * Copyright 2022 Metrological
+ * Copyright 2022 RDK Management
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Reason for change: Copyright needs to be changed
to say RDK Management instead of Metrological.
Test Procedure: None
Risks: None
Signed-off-by: Nikita Poltorapavlo <npoltorapavlo@productengine.com>