### PR TITLE
RDKTV-35827: To list AV1 codec from PlayerInfo

### DIFF
--- a/interfaces/IPlayerInfo.h
+++ b/interfaces/IPlayerInfo.h
@@ -56,7 +56,8 @@ namespace Exchange {
             VIDEO_MPEG4,
             VIDEO_VP8,
             VIDEO_VP9,
-            VIDEO_VP10
+            VIDEO_VP10,
+            VIDEO_AV1
         };
 
         enum PlaybackResolution : uint8_t {


### PR DESCRIPTION
Reason For Change: PlayerInfo service doesn't report AV1 codec though platform supports
Test procedure: Mentioned in the ticket RDKTV-35827
Risks: Low
Signed-off-by: vidhathri_joshi@comcast.com